### PR TITLE
Wrong cache key used in ps_categoryproducts

### DIFF
--- a/ps_categoryproducts.php
+++ b/ps_categoryproducts.php
@@ -346,7 +346,7 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
             return array(
                 'id_product' => $id_product,
                 'id_category' => $id_category,
-                'cache_id' => $cache_id,
+                'cache_id' => $this->getCacheId($cache_id),
             );
         }
 


### PR DESCRIPTION
This pull request fix an issue with cache key
https://github.com/PrestaShop/PrestaShop/issues/9652