### PR TITLE
It should fill the input by the submitted value

### DIFF
--- a/ps_categoryproducts.php
+++ b/ps_categoryproducts.php
@@ -203,8 +203,8 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
     public function getConfigFieldsValues()
     {
         return array(
-            'CATEGORYPRODUCTS_DISPLAY_PRICE' => Configuration::get('CATEGORYPRODUCTS_DISPLAY_PRICE'),
-            'CATEGORYPRODUCTS_DISPLAY_PRODUCTS' => Configuration::get('CATEGORYPRODUCTS_DISPLAY_PRODUCTS'),
+            'CATEGORYPRODUCTS_DISPLAY_PRICE' => Tools::getValue('CATEGORYPRODUCTS_DISPLAY_PRICE', (bool) Configuration::get('CATEGORYPRODUCTS_DISPLAY_PRICE')),
+            'CATEGORYPRODUCTS_DISPLAY_PRODUCTS' => Tools::getValue('CATEGORYPRODUCTS_DISPLAY_PRODUCTS', (int) Configuration::get('CATEGORYPRODUCTS_DISPLAY_PRODUCTS')),
         );
     }
 


### PR DESCRIPTION
In case of erroneous enter, it should fill the input by the same erroneous submitted value to let user verify and correct it

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
