### PR TITLE
Adapt `ps_categoryproducts` for multiples versions of PrestaShop

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.1.2', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
+        presta-versions: ['1.7.1.2', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', '8.0', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/ps_categoryproducts.php
+++ b/ps_categoryproducts.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
-use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
@@ -293,15 +292,27 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
         $assembler = new ProductAssembler($this->context);
         $presenterFactory = new ProductPresenterFactory($this->context);
         $presentationSettings = $presenterFactory->getPresentationSettings();
-        $presenter = new ProductListingPresenter(
-            new ImageRetriever(
-                $this->context->link
-            ),
-            $this->context->link,
-            new PriceFormatter(),
-            new ProductColorsRetriever(),
-            $this->context->getTranslator()
-        );
+        if (version_compare(_PS_VERSION_, '1.7.5', '>=')) {
+            $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter(
+                new ImageRetriever(
+                    $this->context->link
+                ),
+                $this->context->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $this->context->getTranslator()
+            );
+        } else {
+            $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
+                new ImageRetriever(
+                    $this->context->link
+                ),
+                $this->context->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $this->context->getTranslator()
+            );
+        }
 
         $productsForTemplate = [];
 

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -4,4 +4,6 @@ includes:
 parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -4,4 +4,6 @@ includes:
 parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -4,4 +4,6 @@ includes:
 parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -3,4 +3,6 @@ includes:
 
 parameters:
   ignoreErrors:
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given.#'

--- a/tests/phpstan/phpstan-8.0.neon
+++ b/tests/phpstan/phpstan-8.0.neon
@@ -1,0 +1,2 @@
+includes:
+	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adapt `ps_categoryproducts` for multiples versions of PrestaShop
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Relative to PrestaShop/Prestashop#28988
| How to test?  | Try this module in version `< 1.7.4.0` and in recent version (`8.0.0`)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
