### PR TITLE
Remove caching system and bump version to 2.0.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_categoryproducts</name>
     <displayName><![CDATA[Products category]]></displayName>
-    <version><![CDATA[1.0.8]]></version>
+    <version><![CDATA[2.0.0]]></version>
     <description><![CDATA[Displays products of the same category on the product page.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <is_configurable>1</is_configurable>

--- a/ps_categoryproducts.php
+++ b/ps_categoryproducts.php
@@ -48,7 +48,7 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
         $this->name = 'ps_categoryproducts';
         $this->tab = 'pricing_promotion';
         $this->author = 'PrestaShop';
-        $this->version = '1.0.8';
+        $this->version = '2.0.0';
 
         $this->bootstrap = true;
         parent::__construct();
@@ -66,9 +66,6 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
             && Configuration::updateValue('CATEGORYPRODUCTS_DISPLAY_PRICE', 1)
             && Configuration::updateValue('CATEGORYPRODUCTS_DISPLAY_PRODUCTS', 16)
             && $this->registerHook('displayFooterProduct')
-            && $this->registerHook('actionProductAdd')
-            && $this->registerHook('actionProductUpdate')
-            && $this->registerHook('actionProductDelete')
         ;
     }
 
@@ -97,7 +94,6 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
                 Configuration::updateValue('CATEGORYPRODUCTS_DISPLAY_PRICE', Tools::getValue('CATEGORYPRODUCTS_DISPLAY_PRICE'));
                 Configuration::updateValue('CATEGORYPRODUCTS_DISPLAY_PRODUCTS', (int) Tools::getValue('CATEGORYPRODUCTS_DISPLAY_PRODUCTS'));
 
-                $this->_clearCache($this->templateFile);
                 $this->html .= $this->displayConfirmation($this->trans('The settings have been updated.', [], 'Admin.Notifications.Success'));
             }
         }
@@ -105,34 +101,6 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
         $this->html .= $this->renderForm();
 
         return $this->html;
-    }
-
-    public function hookAddProduct($params)
-    {
-        return $this->clearCache($params);
-    }
-
-    public function hookUpdateProduct($params)
-    {
-        return $this->clearCache($params);
-    }
-
-    public function hookDeleteProduct($params)
-    {
-        return $this->clearCache($params);
-    }
-
-    private function clearCache($params)
-    {
-        $params = $this->getInformationFromConfiguration($params);
-
-        if ($params) {
-            $this->_clearCache($this->templateFile, $params['cache_id']);
-        } else {
-            $this->_clearCache($this->templateFile);
-        }
-
-        return;
     }
 
     public function renderForm()
@@ -232,29 +200,23 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
 
         if ($params) {
             if ((int) Configuration::get('CATEGORYPRODUCTS_DISPLAY_PRODUCTS') > 0) {
-                // Need variables only if this template isn't cached
-                if (!$this->isCached($this->templateFile, $params['cache_id'])) {
-                    if (!empty($params['id_category'])) {
-                        $category = new Category((int) $params['id_category']);
-                    }
-
-                    if (empty($category) || !Validate::isLoadedObject($category) || !$category->active) {
-                        return false;
-                    }
-
-                    $variables = $this->getWidgetVariables($hookName, $configuration);
-
-                    if (empty($variables)) {
-                        return false;
-                    }
-
-                    $this->smarty->assign($variables);
+                if (!empty($params['id_category'])) {
+                    $category = new Category((int) $params['id_category']);
                 }
 
-                return $this->fetch(
-                    $this->templateFile,
-                    $params['cache_id']
-                );
+                if (empty($category) || !Validate::isLoadedObject($category) || !$category->active) {
+                    return false;
+                }
+
+                $variables = $this->getWidgetVariables($hookName, $configuration);
+
+                if (empty($variables)) {
+                    return false;
+                }
+
+                $this->smarty->assign($variables);
+
+                return $this->fetch($this->templateFile);
             }
         }
 
@@ -356,12 +318,9 @@ class Ps_Categoryproducts extends Module implements WidgetInterface
         $id_category = (isset($configuration['category']->id) ? (int) $configuration['category']->id : (int) $product['id_category_default']);
 
         if (!empty($id_product) && !empty($id_category)) {
-            $cache_id = 'ps_categoryproducts|' . $id_product . '|' . $id_category;
-
             return [
                 'id_product' => $id_product,
                 'id_category' => $id_category,
-                'cache_id' => $this->getCacheId($cache_id),
             ];
         }
 

--- a/upgrade/upgrade-2.0.0.php
+++ b/upgrade/upgrade-2.0.0.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_0_0($module)
+{
+    $module->unregisterHook('actionProductAdd');
+    $module->unregisterHook('actionProductUpdate');
+    $module->unregisterHook('actionProductDelete');
+
+    return true;
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Removes caching system from this module to fix all issues with outdated data being displayed on homepage. Once you display anything more than a price on the product miniature, the data is outdated. Availability displays yesterdays date or wrong message. There is only a negligible slowdown, it's only 8 products, we load much more in a category, where there is no caching.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.